### PR TITLE
Importer::ETD: fix when run with `-m`

### DIFF
--- a/lib/importer/etd.rb
+++ b/lib/importer/etd.rb
@@ -69,7 +69,10 @@ module Importer::ETD
         # so pull the individual records into a regular
         # Array; see
         # https://github.com/ruby-marc/ruby-marc/pull/47
-        MARC::XMLReader.new(m).map { |o| o }
+        MARC::XMLReader.new(m).map { |o| o }.select do |record|
+          # only keep records for which we've provided data
+          etds.any? { |etd| etd[:pdf].include? record["956"]["f"] }
+        end
       end
     end.flatten
   end


### PR DESCRIPTION
When we provided metadata explicitly instead of by letting the SRU download it during the ingest, the importer failed to sort out the metadata that corresponds to the data passed with `-d`; instead it would just try to ingest all the metadata it was given.