### PR TITLE
config/development: prevent double-loading error

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
-  # Settings specified here will take precedence over those in
-  # config/application.rb.
-
-  # In the development environment your application's code is reloaded
-  # on every request. This slows down response time but is perfect for
-  # development since you don't have to restart the web server when
-  # you make code changes.
-  config.cache_classes = false
+  config.cache_classes = true
 
   # Do not eager load code on boot.
   config.eager_load = false


### PR DESCRIPTION
```
🔥  VERBOSE=1 QUEUE='*' INTERVAL=5 bin/rake resque:work --trace
** Invoke resque:work (first_time)
** Invoke resque:preload (first_time)
** Invoke resque:setup (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute resque:setup
** Execute resque:preload
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:5: warning: already initialized constant Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:5: warning: previous definition of PERMISSION_TEXT_VALUE_PUBLIC was here
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:6: warning: already initialized constant Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:6: warning: previous definition of PERMISSION_TEXT_VALUE_AUTHENTICATED was here
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:9: warning: already initialized constant Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:9: warning: previous definition of VISIBILITY_TEXT_VALUE_PUBLIC was here
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:10: warning: already initialized constant Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:10: warning: previous definition of VISIBILITY_TEXT_VALUE_EMBARGO was here
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:11: warning: already initialized constant Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:11: warning: previous definition of VISIBILITY_TEXT_VALUE_LEASE was here
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:12: warning: already initialized constant Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:12: warning: previous definition of VISIBILITY_TEXT_VALUE_AUTHENTICATED was here
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:13: warning: already initialized constant Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/access_right.rb:13: warning: previous definition of VISIBILITY_TEXT_VALUE_PRIVATE was here
rake aborted!
ActiveSupport::Concern::MultipleIncludedBlocks: Cannot define multiple 'included' blocks for a Concern
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/concern.rb:126:in `included'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/embargoable.rb:7:in `<module:Embargoable>'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/embargoable.rb:3:in `<module:AccessControls>'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/embargoable.rb:2:in `<module:Hydra>'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/hydra-access-controls-10.5.0/app/models/concerns/hydra/access_controls/embargoable.rb:1:in `<top (required)>'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies.rb:477:in `load'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies.rb:477:in `block in load_file'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies.rb:662:in `new_constants_in'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies.rb:476:in `load_file'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies.rb:375:in `block in require_or_load'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies.rb:37:in `block in load_interlock'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies/interlock.rb:12:in `block in loading'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/concurrency/share_lock.rb:150:in `exclusive'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies/interlock.rb:11:in `loading'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies.rb:37:in `load_interlock'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies.rb:358:in `require_or_load'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies.rb:336:in `depend_on'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.5/lib/active_support/dependencies.rb:252:in `require_dependency'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.5/lib/rails/engine.rb:476:in `block (2 levels) in eager_load!'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.5/lib/rails/engine.rb:475:in `each'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.5/lib/rails/engine.rb:475:in `block in eager_load!'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.5/lib/rails/engine.rb:473:in `each'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.5/lib/rails/engine.rb:473:in `eager_load!'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.5/lib/rails/engine.rb:354:in `eager_load!'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/resque-1.27.4/lib/resque/tasks.rb:45:in `each'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/resque-1.27.4/lib/resque/tasks.rb:45:in `block (2 levels) in <top (required)>'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `block in execute'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `each'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `execute'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb:194:in `block in invoke_with_call_chain'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb:187:in `invoke_with_call_chain'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb:216:in `block in invoke_prerequisites'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb:214:in `each'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb:214:in `invoke_prerequisites'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb:193:in `block in invoke_with_call_chain'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb:187:in `invoke_with_call_chain'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb:180:in `invoke'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/application.rb:152:in `invoke_task'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/application.rb:108:in `block (2 levels) in top_level'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/application.rb:108:in `each'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/application.rb:108:in `block in top_level'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/application.rb:117:in `run_with_threads'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/application.rb:102:in `top_level'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/application.rb:80:in `block in run'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/application.rb:178:in `standard_exception_handling'
/Users/alex/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/application.rb:77:in `run'
bin/rake:6:in `<main>'
Tasks: TOP => resque:work => resque:preload
```