### PR TITLE
ObjectFactoryWriter: fix cylinder file parsing

### DIFF
--- a/lib/object_factory_writer.rb
+++ b/lib/object_factory_writer.rb
@@ -51,7 +51,7 @@ class ObjectFactoryWriter
     {
       language: [],
       created_start: [],
-      fulltext_link: [],
+      fulltext_link: (traject_context[:fulltext_link] || []),
     }.merge(traject_context)
       .merge(transform_traject_attrs(traject_context))
       .merge(etd_attributes)
@@ -92,8 +92,8 @@ class ObjectFactoryWriter
     return @etd if @etd
     return [] if @settings[:files_dirs].blank?
 
-    file_groups = attributes[:filename].map do |name|
-      match = name.match('Cylinder\ (\d+)')
+    file_groups = attributes[:fulltext_link].map do |name|
+      match = name.match(/.*Cylinder(\d+)$/)
       next if match.blank?
       cylinder_number = match[1]
 

--- a/lib/traject/audio_config.rb
+++ b/lib/traject/audio_config.rb
@@ -78,6 +78,3 @@ to_field "system_number", extract_marc("001")
 to_field "table_of_contents", extract_marc("505agrtu68")
 to_field "title", extract_marc("245abnp", trim_punctuation: true)
 to_field "work_type", extract_work_type
-
-# This is the cylinder name
-to_field "filename", extract_marc("852j")

--- a/spec/fixtures/cylinders/cylinders-objects.xml
+++ b/spec/fixtures/cylinders/cylinders-objects.xml
@@ -77,6 +77,10 @@
     <subfield code="3">Audio files:</subfield>
     <subfield code="u">http://www.library.ucsb.edu/OBJID/Cylinder0006</subfield>
   </datafield>
+  <datafield tag="856" ind1="4" ind2="1">
+    <subfield code="3">Audio files:</subfield>
+    <subfield code="u">http://www.library.ucsb.edu/OBJID/Cylinder12783</subfield>
+  </datafield>
   <datafield tag="852" ind1="4" ind2="0">
     <subfield code="a">CU-SB</subfield>
     <subfield code="b">MAIN</subfield>

--- a/spec/lib/object_factory_writer_spec.rb
+++ b/spec/lib/object_factory_writer_spec.rb
@@ -87,7 +87,14 @@ describe ObjectFactoryWriter do
   describe "#find_files_to_attach" do
     subject { writer.find_files_to_attach(attrs) }
 
-    let(:attrs) { { filename: ["Cylinder 12783", "Cylinder 0001"] } }
+    let(:attrs) do
+      {
+        fulltext_link: [
+          "http://library.ucsb.edu/OBJID/Cylinder12783",
+          "http://library.ucsb.edu/OBJID/Cylinder0001",
+        ],
+      }
+    end
 
     context "with ETDs" do
       # rubocop:disable Metrics/LineLength
@@ -149,7 +156,7 @@ describe ObjectFactoryWriter do
     end
 
     context "with a bad cylinder name" do
-      let(:attrs) { { filename: ["PA Mss 42"] } }
+      let(:attrs) { { fulltext_link: ["PA Mss 42"] } }
       let(:files_dirs) { [File.join(fixture_path, "cylinders")] }
 
       it "continues without an error" do


### PR DESCRIPTION
As part of a recent refactor that wasn't fully tested with cylinder
ingests, `attributes[:filename]` is no longer used.