### PR TITLE
slideshow: fix display of thumbnails

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -583,9 +583,9 @@ table#downloads {
 
   a > img {
     height: auto;
-    left: initial;
+    left: 0;
     position: unset;
-    top: initial;
+    top: 0;
     width: 100px;
   }
 }


### PR DESCRIPTION
**Currently**
<img width="481" alt="screen shot 2017-09-18 at 2 34 45 pm" src="https://user-images.githubusercontent.com/985416/30565847-a9f627b6-9c7e-11e7-93f9-512e3e06af98.png">
***********
**Fixed**
<img width="483" alt="screen shot 2017-09-18 at 2 34 19 pm" src="https://user-images.githubusercontent.com/985416/30565860-b0e35e90-9c7e-11e7-8a56-5d064e152163.png">
