### PR TITLE
Revert "ObjectFactory#remove_existing_filesets: reload before saving"

### DIFF
--- a/lib/importer/factory/object_factory.rb
+++ b/lib/importer/factory/object_factory.rb
@@ -160,8 +160,8 @@ module Importer::Factory
       object.file_sets.each do |f|
         CurationConcerns::Actors::FileSetActor.new(f, nil).destroy
       end
-      object.reload.file_sets
       object.save
+      object.reload.file_sets
     end
 
     # @param [Hash] attrs


### PR DESCRIPTION
When things are working correctly, we actually get an error if we
_don't_ save first.

This reverts commit 883b2de8ec8009b661fb0803cb3006ef6a6f3386.