### PR TITLE
Add version to footer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -479,6 +479,11 @@ footer {
 .copyright {
   font-size: 82.5%;
 }
+
+.version {
+  font-size: 82.5%;
+}
+
 .ucsb-small {
   float: left;
   clear: right;

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,6 +3,9 @@
     <div class="copyright">
       Copyright 2014–<%= Date.today.year %> The Regents of the University of California, All Rights Reserved.
     </div>
+    <div class="version">
+      Version <%= BRANCH %> updated <%= LAST_DEPLOYED %>
+    </div>
   </div>
 
   <div class="meta-ucsb">

--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+revisions_logfile = Rails.root.parent.parent.join("revisions.log")
+
+GIT_SHA =
+  if Rails.env.production? && File.exist?(config.revisions_logfile)
+    `tail -1 #{revisions_logfile}`.chomp.split(" ")[3].gsub(/\)$/, "")
+  elsif Rails.env.development? || Rails.env.test?
+    `git rev-parse HEAD`.chomp
+  else
+    "Unknown SHA"
+  end
+
+BRANCH =
+  if Rails.env.production? && File.exist?(config.revisions_logfile)
+    `tail -1 #{revisions_logfile}`.chomp.split(" ")[1]
+  elsif Rails.env.development? || Rails.env.test?
+    `git rev-parse --abbrev-ref HEAD`.chomp
+  else
+    "Unknown branch"
+  end
+
+LAST_DEPLOYED =
+  if Rails.env.production? && File.exist?(config.revisions_logfile)
+    deployed = `tail -1 #{revisions_logfile}`.chomp.split(" ")[7]
+    Date.parse(deployed).strftime("%d %B %Y")
+  else
+    "Not in deployed environment"
+  end


### PR DESCRIPTION
This commit adds a version to the footer. This includes the
branch or tag that the software is on along with the SHA. The
SHA is only visible if you hover over the branch name.

This is based on the instructions at:
https://curationexperts.github.io/playbook/every_project/git_sha.html

It is using this path to `revisions.log`:

`/opt/alexandria/revisions.log`