### PR TITLE
Add full text searching for PDFs

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -104,6 +104,7 @@ class CatalogController < ApplicationController
         lc_subject_label_tesim
         location_label_tesim
         title_tesim
+        all_text_timv
       ].join(" "),
       wt: "json",
       qt: "search",

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationJob < ActiveJob::Base
+end

--- a/app/jobs/full_text_to_solr_job.rb
+++ b/app/jobs/full_text_to_solr_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+##
+# a job class that will update a Solr document
+# with the extracted text of an attached PDF
+class FullTextToSolrJob < ApplicationJob
+  # @return [String] the id for the SolrDocument being updated
+  # @return [IO] the PDF content
+  attr_reader :solr_document_id, :work_content
+
+  queue_as :default
+
+  def initialize(solr_document_id, work_content)
+    @solr_document_id = solr_document_id
+    @work_content = work_content
+  end
+
+  def perform
+    solr = RSolr.connect(url: ActiveFedora::SolrService.instance.conn.uri.to_s)
+    solr_document = SolrDocument.find(@solr_document_id).to_h
+    solr_document["all_text_timv"] = FullTextExtractor.new(@work_content).text
+    solr.add(solr_document)
+    solr.commit
+  end
+end

--- a/lib/full_text_extractor.rb
+++ b/lib/full_text_extractor.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+##
+# This class sends a PDF IO object to the Solr text extraction service
+# and retrieves the JSON that is returned by Solr
+class FullTextExtractor
+  # @return [String] The text extracted from the PDF
+  attr_reader :text
+
+  # Initilize with PDF IO and send to the solr extract
+  # service
+  # @param file [IO]
+  def initialize(file)
+    uri =  URI(ActiveFedora::SolrService.instance.conn.uri +
+               "update/extract?extractOnly=true&wt=json&extractFormat=text")
+
+    http = Net::HTTP.start(uri.host, uri.port)
+    req = Net::HTTP::Post.new(uri.request_uri)
+    req.body = file
+    req.add_field("Content-Type", "application/pdf")
+    req.add_field("enctype", "multipart/form-data")
+    @text = http.request(req).body.as_json.strip.force_encoding("UTF-8")
+  end
+end

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -17,11 +17,11 @@
 -->
 
 <!--
- This is a stripped down config file used for a simple example...  
- It is *not* a good example to work from. 
+ This is a stripped down config file used for a simple example...
+ It is *not* a good example to work from.
 -->
 <config>
-  
+
   <!-- Controls what version of Lucene various components of Solr
        adhere to.  Generally, you want to use the latest version to
        get all bug fixes and improvements. It is highly recommended
@@ -29,15 +29,15 @@
        affect both how text is indexed and queried.
   -->
   <luceneMatchVersion>5.0.0</luceneMatchVersion>
-  
+
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
   <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
   <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar" />
 
-  <directoryFactory name="DirectoryFactory" 
+  <directoryFactory name="DirectoryFactory"
                     class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}">
-  </directoryFactory> 
+  </directoryFactory>
 
   <codecFactory class="solr.SchemaCodecFactory"/>
 
@@ -45,14 +45,14 @@
 
 
   <dataDir>${solr.blacklight-core.data.dir:}</dataDir>
-  
+
   <requestDispatcher handleSelect="true" >
-    <requestParsers enableRemoteStreaming="false" multipartUploadLimitInKB="2048000" />
+    <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048000" formdataUploadLimitInKB="2048000" />
   </requestDispatcher>
-  
+
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
 
-  <!-- config for the admin interface --> 
+  <!-- config for the admin interface -->
   <admin>
     <defaultQuery>*:*</defaultQuery>
   </admin>
@@ -201,7 +201,7 @@
 <!-- Spell Check
 
         The spell check component can return a list of alternative spelling
-        suggestions.  
+        suggestions.
 
         http://wiki.apache.org/solr/SpellCheckComponent
      -->
@@ -256,7 +256,7 @@
        </lst>
      -->
 
-    <!-- a spellchecker that use an alternate comparator 
+    <!-- a spellchecker that use an alternate comparator
 
          comparatorClass be one of:
           1. score (default)
@@ -319,4 +319,3 @@
     <!-- </lst> -->
   </requestHandler>
 </config>
-

--- a/spec/jobs/full_text_to_solr_job_spec.rb
+++ b/spec/jobs/full_text_to_solr_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FullTextToSolrJob do
+  let(:file) do
+    File.open(Rails.root.join("spec", "fixtures", "pdf", "sample_full.pdf")).read
+  end
+  let(:image) { FactoryBot.create(:public_image) }
+  let(:ftts) { described_class.new(image.id, file) }
+  let(:solr) { RSolr.connect(url: ActiveFedora::SolrService.instance.conn.uri.to_s) }
+
+  describe "#perform" do
+    it "adds the text to solr index" do
+      ftts.perform_now
+      response = solr.get "select", params: { q: "John Arnhold", qf: "all_text_timv" }
+      num_found = response["response"]["numFound"]
+      expect(num_found).to eq(1)
+    end
+  end
+end

--- a/spec/lib/full_text_extractor_spec.rb
+++ b/spec/lib/full_text_extractor_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FullTextExtractor do
+  let(:file) do
+    File.open(Rails.root.join("spec", "fixtures", "pdf", "sample_full.pdf")).read
+  end
+  let(:fte) { described_class.new(file) }
+
+  describe "getting some json that contains the text of a pdf" do
+    it "returns some json" do
+      expect(fte.text).to match(/John Arnhold/)
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces two classes that can be used
to index full text content of PDFs intro Solr.

There is a `FullTextExtractor` class and a
`FullTextToSolrJob` class. The first one handles
getting the the extracted text from Solr by posting
the PDF data to Solr. The job class gets the full text
and updates the Solr index with the text.

To run the job:

```ruby
FullTextToSolrJob.new("fk4jq25q2f", Image.first.file_sets[0].files.first.content).perform
```

The first param is the `SolrDocument` id, and the second param is a PDF datastream
in an ActiveFedora object.