### PR TITLE
SRU: fix cylinder query

### DIFF
--- a/config/sru.yml
+++ b/config/sru.yml
@@ -9,6 +9,6 @@ default_params:
   - "alma.mms_tagSuppressed=false"
 ark_query: "(alma.standard_number=%<ark>s)"
 binary_query: "(alma.local_field_956=%<binary>s)"
-cylinder_query: "(alma.all_for_ui=http://www.library.ucsb.edu/OBJID/Cylinder*)"
+cylinder_query: "(alma.all_for_ui=www.library.ucsb.edu/OBJID/Cylinder*)"
 cylinder_query_single: "(alma.all_for_ui=*OBJID/Cylinder%<number>s)"
 etd_query: "(alma.local_field_947=pqd)"


### PR DESCRIPTION
Fixes ALMA-646.

From the JIRA ticket:
```
I learned 2 things from submitting this problem to Ex Libris.

1. You can report this type of problem directly to the Developers Forum, at: https://developers.exlibrisgroup.com/discussions#!/forum/forums/show/5.page which is what Ex Libris asked me to do
2. The reply I got from the Developers Forum is that the SRU alma.all_for_ui works but you have to remove "http://" from the query otherwise it returns no results:
https://ucsb.alma.exlibrisgroup.com/view/sru/01UCSB_INST?version=1.2&operation=searchRetrieve&alma.mms_tagSuppressed=false&maximumRecords=1&startRecord=1&query=(alma.all_for_ui=www.library.ucsb.edu/OBJID/Cylinder*)
```
cc @chrissyrissmeyer @jenlindner 