### PR TITLE
Full-text indexing on imported objects

### DIFF
--- a/app/jobs/full_text_to_solr_job.rb
+++ b/app/jobs/full_text_to_solr_job.rb
@@ -6,29 +6,33 @@
 class FullTextToSolrJob < ApplicationJob
   # @return [String] the id for the SolrDocument being updated
   # @return [IO] the PDF content
-  attr_reader :work_id
+  attr_reader :work_id, :logger
 
   queue_as :default
 
-  def initialize(work_id)
+  def initialize(work_id, logger = Logger.new(STDOUT))
     @work_id = work_id
+    @logger = logger
   end
 
   def perform
-    solr = RSolr.connect(url: ActiveFedora::SolrService.instance.conn.uri.to_s)
+    return if all_text.nil?
     solr_document = SolrDocument.find(@work_id).to_h
     solr_document["all_text_timv"] = all_text
-    solr.add(solr_document)
-    solr.commit
+    ActiveFedora::SolrService.add(solr_document)
+    ActiveFedora::SolrService.commit
+    @logger.info("Full text indexed for work: #{@work_id}")
   end
 
   private
 
     def files
+      return nil if ActiveFedora::Base.find(@work_id).class == Collection
       ActiveFedora::Base.find(@work_id).file_sets.map(&:files).flatten
     end
 
     def all_text
+      return nil if files.nil?
       files.map { |file| FullTextExtractor.new(file.content).text }.join("")
     end
 end

--- a/lib/importer/factory/object_factory.rb
+++ b/lib/importer/factory/object_factory.rb
@@ -95,6 +95,8 @@ module Importer::Factory
 
       logger.info "Created #{klass.model_name.human} #{object.id} "\
                   "(#{Array(attributes[system_identifier_field]).first})"
+      # Full-Text Indexing
+      ::FullTextToSolrJob.new(object.id, @logger).perform
     end
 
     def update

--- a/spec/lib/importer/csv_full_text_indexing_spec.rb
+++ b/spec/lib/importer/csv_full_text_indexing_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "active_fedora/cleaner"
+require "rails_helper"
+require "importer"
+require "parse"
+require "httparty"
+
+describe Importer::CSV do
+  before do
+    ActiveFedora::Cleaner.clean!
+    AdminPolicy.ensure_admin_policy_exists
+  end
+
+  let(:data) { Dir["#{fixture_path}/pdf/*"] }
+  let(:logger) { Logger.new(STDOUT) }
+  let(:connection_url) { ActiveFedora::SolrService.instance.conn.uri }
+
+  context "full-text indexing" do
+    let(:metadata) { ["#{fixture_path}/csv/pdf.csv"] }
+
+    it "creates a new pdf with full text indexed" do
+      VCR.use_cassette("csv_importer") do
+        described_class.import(
+          meta: metadata,
+          data: data,
+          options: { skip: 0 },
+          logger: logger
+        )
+      end
+      expect(Image.count).to eq(1)
+      result = HTTParty.get(
+        "#{connection_url}select?&q=exxon&qf=all_text_timv&wt=json"
+      )
+      expect(result.parsed_response["response"]["numFound"]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
This modifies the object_factory class used
by the importer to perform a full text indexing
job on the object.

This is tested by a new spec that that imports a CSV
with an attached PDF and performs a solr query to check
for text that is inside the PDF.

Closes curationexperts/alexandria#48