### PR TITLE
Add alexandria url prefix to identifier for OAI

### DIFF
--- a/app/indexers/object_indexer.rb
+++ b/app/indexers/object_indexer.rb
@@ -57,6 +57,9 @@ class ObjectIndexer < CurationConcerns::WorkIndexer
         s.respond_to?(:rdf_label) ? s.rdf_label : s
       end.flatten
 
+      solr_doc["uri_ssm"] =
+        "#{Settings.oai_identifier_prefix}#{object.identifier.first}"
+
       yield(solr_doc) if block_given?
     end
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -37,9 +37,9 @@ class SolrDocument
     creator: "creator_tesim",
     date: "date_si",
     format: "form_of_work_label_tesim",
-    identifier: "identifier_ssm",
+    identifier: "uri_ssm",
     publisher: "publisher_tesim",
-    relation: %w[collection_label_ssim square_thumbnail_url_ssm],
+    relation: "collection_label_ssim",
     rights: "license_tesim",
     type: "work_type_label_tesim"
   )

--- a/config/application.yml
+++ b/config/application.yml
@@ -27,6 +27,7 @@ defaults: &defaults
   oai_repository_name: "Alexandria Digital Research Library"
   oai_repository_url: "https://alexandria.ucsb.edu/catalog/oai"
   oai_record_prefix: "oai:ucsb"
+  oai_identifier_prefix: "https://alexandria.ucsb.edu/lib/"
   uploads_dir: <%= ENV['ADRL_UPLOADS'] || Rails.root.join("tmp", "uploads") %>
 
 development:

--- a/spec/requests/oai_spec.rb
+++ b/spec/requests/oai_spec.rb
@@ -38,8 +38,9 @@ RSpec.describe "Oai requests", type: :request do
     expect(response.body).to match(%r{<dc:title>.*<\/dc:title>})
   end
 
-  it "has a record in the repo with a dc identifier" do
+  it "has a record in the repo with a dc identifier with an http prefix" do
     get "/catalog/oai?verb=ListRecords&metadataPrefix=oai_dc"
-    expect(response.body).to match(%r{<dc:identifier>.*<\/dc:identifier>})
+    prefix_id = %r{<dc:identifier>https://alexandria.ucsb.edu/lib/.*<\/dc:identifier>}
+    expect(response.body).to match(prefix_id)
   end
 end


### PR DESCRIPTION
This adds a url prefix to the identifier element in the
OAI-PMH feed. The rules in Primo are setup so that they
check for the http prefix to create links.

This creates a configuration option to set the prefix and
concats the prefix to existing identifier element in the solr
document via the `ObjectIndexer`.