### PR TITLE
bin/marc: require SRU module

### DIFF
--- a/bin/marc
+++ b/bin/marc
@@ -5,6 +5,7 @@ $stdout.sync = true # flush output immediately
 
 puts "Loading environment..."
 require File.expand_path("../config/environment", __dir__)
+require "sru"
 
 # If there are no options given, invoke help
 ARGV << "-h" if ARGV.empty?


### PR DESCRIPTION
It should be autoloaded, but we're getting an error trying to run this
on a production server.