### PR TITLE
Fixes DIGREPO-937 Import merritt arks for ETDs

### DIFF
--- a/app/models/concerns/metadata.rb
+++ b/app/models/concerns/metadata.rb
@@ -39,6 +39,11 @@ module Metadata
       index.as :displayable
     end
 
+    # For Merritt ARKs
+    property :merritt_id, predicate: RDF::Vocab::DC.identifier do |index|
+      index.as :displayable
+    end
+
     property :accession_number,
              predicate: RDF::URI(
                "http://opaquenamespace.org/ns/cco/accessionNumber"

--- a/app/models/concerns/metadata.rb
+++ b/app/models/concerns/metadata.rb
@@ -40,9 +40,7 @@ module Metadata
     end
 
     # For Merritt ARKs
-    property :merritt_id, predicate: RDF::Vocab::DC.identifier do |index|
-      index.as :displayable
-    end
+    property :merritt_id, predicate: RDF::Vocab::DC11.identifier
 
     property :accession_number,
              predicate: RDF::URI(

--- a/doc/ingesting.md
+++ b/doc/ingesting.md
@@ -5,7 +5,7 @@ The descriptive metadata repository is automatically cloned to
 up-to-date when running ingests.
 
 The remote fileshare with supporting images is automatically mounted
-to `/opt/ingest/data`.
+to `/opt/ingest/repository`.
 
 Some ingests trigger background jobs, which are handled by Resque.
 The web interface for Resque can be started with the following:
@@ -72,14 +72,14 @@ RAILS_ENV=production bin/ingest -f mods -m /opt/ingest/metadata/adrl-dm/ingest-r
 Then ingest ETDs:
 
 ```
-RAILS_ENV=production bin/ingest -f etd -d /opt/ingest/data/etds/2adrl_ready/*.zip
+RAILS_ENV=production bin/ingest -f etd -d /opt/ingest/repository/etds/2adrl_ready/*.zip
 ```
 
 Currently, because we’re using a local modification to collection
 membership (see {file:local_collections.md}), we need to update the
 ETD collection after ingesting members:
 
-```
+``` 
 irb> etd_collection.update_index
 ```
 
@@ -117,7 +117,7 @@ you can provide the directory that contains both the `collection` and
 `objects` metadata directories:
 
 ```
-RAILS_ENV=production bin/ingest -f mods -m /opt/data/ingest/metadata/adrl-dm/ingest-ready/sbhcmss036/ -d /opt/data/images/sbhcmss036/
+RAILS_ENV=production bin/ingest -f mods -m /opt/ingest/metadata/adrl-dm/ingest-ready/sbhcmss036/ -d /opt/ingest/repository/images/sbhcmss036/
 ```
 
 ### Ingesting CSV records

--- a/doc/solr_and_fedora.md
+++ b/doc/solr_and_fedora.md
@@ -24,67 +24,21 @@ We are using the gems `solr_wrapper` and `fcrepo_wrapper` to run solr and fedora
    You should be able to download the files from the [Apache Archive](http://archive.apache.org/dist/lucene/solr)
 
 ## Example config files
-
-Here are some files that I have used.  Note that I am running my dev and test environments on the same port.  You might want to use different ports if you intend to run specs at the same time that your dev environment is running.
-
-Example file `.solr_wrapper_dev`:
-
-```ruby
-version: 5.5.0
-port: 8983
-download_dir: tmp/solr_download
-instance_dir: tmp/solr
-collection:
-    persist: true
-    dir: solr/config/
-    name: development
-```
-
-Example file `.solr_wrapper_test`:
-
-```ruby
-version: 5.5.0
-port: 8983
-download_dir: tmp/solr_download
-instance_dir: tmp/solr
-collection:
-    persist: false
-    dir: solr/config/
-    name: test
-```
-
-Example file `.fcrepo_wrapper_dev`:
-
-```ruby
-port: 8984
-enable_jms: false
-version: 4.5.0
-download_dir: tmp/fedora/download
-instance_dir: tmp/fedora
-fcrepo_home_dir: tmp/fedora/dev
-```
-Example file `.fcrepo_wrapper_test`:
-
-```ruby
-port: 8984
-enable_jms: false
-version: 4.5.0
-download_dir: tmp/fedora/download
-instance_dir: tmp/fedora
-fcrepo_home_dir: tmp/fedora/test
-```
+The app uses 2 separate configs for development and test environments. 
+See `config/solr_wrapper_development.yml` & `config/solr_wrapper_test.yml` for solr config.     
+See `config/fedora_wrapper_development.yml` & `config/fedora_wrapper_test.yml` for fedora config.
 
 ## Running solr and fedora
 
-To run solr using your config file:
+To run solr in development mode:
 
 ```bash
-$ solr_wrapper --config .solr_wrapper_dev
+$ bundle exec solr_wrapper --config config/solr_wrapper_development.yml
 ```
 
-To run fedora using your config file:
+To run fedora in development mode:
 ```bash
-$ fcrepo_wrapper --config .fcrepo_wrapper_dev
+$ bundle exec fcrepo_wrapper --config config/fcrepo_wrapper_development.yml
 ```
 
 ## Running the specs
@@ -93,7 +47,7 @@ $ fcrepo_wrapper --config .fcrepo_wrapper_dev
 * Make sure marmotta is running, or CI environment variable is set to bypass marmotta
 
 ```bash
-$ solr_wrapper --config .solr_wrapper_test
-$ fcrepo_wrapper --config .fcrepo_wrapper_test
+$ bundle exec solr_wrapper --config config/solr_wrapper_test.yml
+$ bundle exec fcrepo_wrapper --config config/fcrepo_wrapper_test.yml
 $ bundle exec rake spec
 ```

--- a/lib/importer/etd.rb
+++ b/lib/importer/etd.rb
@@ -12,7 +12,7 @@ module Importer::ETD
   # @param [Logger] logger
   # @return [Integer]
   def self.import(meta:, data:, options: {}, logger: Logger.new(STDOUT))
-    raise ArgumentError, "Nothing found in data: #{data.inspect}" if data.blank?
+    raise ArgumentError, "Nothing found in data: #{data.inspect}" if data.empty?
     collection = ensure_collection_exists(logger: logger)
     ingests = 0
 
@@ -54,7 +54,7 @@ module Importer::ETD
   end
 
   def self.extract_marc(meta:, data:, logger: Logger.new(STDOUT))
-    if meta.blank?
+    if meta.empty?
       logger.info "No metadata provided; fetching from Pegasus"
       data.map { |e| e[:xml] }.map do |x|
         raise IngestError, "Bad zipfile source: #{e}" if x.nil?

--- a/lib/importer/etd.rb
+++ b/lib/importer/etd.rb
@@ -54,7 +54,7 @@ module Importer::ETD
   end
 
   def self.extract_marc(meta:, data:, logger: Logger.new(STDOUT))
-    if meta.empty?
+    if meta.blank?
       logger.info "No metadata provided; fetching from Pegasus"
       data.map { |e| e[:xml] }.map do |x|
         raise IngestError, "Bad zipfile source: #{e}" if x.nil?

--- a/lib/importer/etd.rb
+++ b/lib/importer/etd.rb
@@ -12,7 +12,7 @@ module Importer::ETD
   # @param [Logger] logger
   # @return [Integer]
   def self.import(meta:, data:, options: {}, logger: Logger.new(STDOUT))
-    raise ArgumentError, "Nothing found in #{data}" if data.empty?
+    raise ArgumentError, "Nothing found in data: #{data.inspect}" if data.blank?
     collection = ensure_collection_exists(logger: logger)
     ingests = 0
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -11,7 +11,7 @@ namespace :import do
     # Proquest ID,Meritt Ark,UCSB Ark
     # ProQuestID:0035D,ark:/13030/m00999g9,ark:/48907/f30865g5
 
-    puts "Beginning Import #{Time.now}"
+    puts "Beginning Import #{Time.zone.now}"
     csv_text = File.read("tmp/ucsb_merritt_etds.csv")
     csv = CSV.parse(csv_text, headers: true)
     missing_etds = []
@@ -31,6 +31,6 @@ namespace :import do
       end
     end
     puts "Missing ETDs: #{missing_etds.inspect}" if missing_etds.present?
-    puts "Import Complete #{Time.now}"
+    puts "Import Complete #{Time.zone.now}"
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -11,7 +11,7 @@ namespace :import do
     # Proquest ID,Meritt Ark,UCSB Ark
     # ProQuestID:0035D,ark:/13030/m00999g9,ark:/48907/f30865g5
 
-    puts "Beginning Import"
+    puts "Beginning Import #{Time.now}"
     csv_text = File.read("tmp/ucsb_merritt_etds.csv")
     csv = CSV.parse(csv_text, headers: true)
     missing_etds = []
@@ -31,6 +31,6 @@ namespace :import do
       end
     end
     puts "Missing ETDs: #{missing_etds.inspect}" if missing_etds.present?
-    puts "Import Complete"
+    puts "Import Complete #{Time.now}"
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -6,7 +6,7 @@ namespace :import do
   task merritt_arks: :environment do
     # CSV file contents as below
     # Proquest ID,Meritt Ark,UCSB Ark
-    # ProQuestID:10951,ark:/13030/m30865g5,ark:/48907/f30865g5
+    # ProQuestID:10951,ark:/13030/m00999g9,ark:/48907/f30865g5
     Rails.logger.info "Complete"
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :import do
+  desc "Import merritt arks from csv for UCSB ETDs"
+
+  task merritt_arks: :environment do
+    # CSV file contents as below
+    # Proquest ID,Meritt Ark,UCSB Ark
+    # ProQuestID:10951,ark:/13030/m30865g5,ark:/48907/f30865g5
+    Rails.logger.info 'Complete'
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,12 +1,36 @@
 # frozen_string_literal: true
+require 'csv'
 
 namespace :import do
   desc "Import merritt arks from csv for UCSB ETDs"
 
   task merritt_arks: :environment do
-    # CSV file contents as below
+    # To run the task on the ETD fixture at
+    # spec/fixtures/proquest/zipped/ETD_ucsb_0035D_13132.zip
+    # CSV file contents would be as below
     # Proquest ID,Meritt Ark,UCSB Ark
-    # ProQuestID:10951,ark:/13030/m00999g9,ark:/48907/f30865g5
-    Rails.logger.info "Complete"
+    # ProQuestID:0035D,ark:/13030/m00999g9,ark:/48907/f30865g5
+
+    puts "Beginning Import"
+    csv_text = File.read('tmp/ucsb_merritt_etds.csv')
+    csv = CSV.parse(csv_text, :headers => true)
+    missing_etds = []
+
+    csv.each do |row|
+      ucsb_ark = row[2].split('/').last
+      merritt_ark = row[1]
+
+      begin
+        etd = ETD.find ucsb_ark
+        next if etd.merritt_id.present?
+        etd.merritt_id = Array[merritt_ark]
+        etd.save
+        puts "Updated UCSB ETD: #{ucsb_ark}"
+      rescue ActiveFedora::ObjectNotFoundError
+        missing_etds << ucsb_ark
+      end
+    end
+    puts "Missing ETDs: #{missing_etds.inspect}" unless missing_etds.blank?
+    puts "Import Complete"
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -7,6 +7,6 @@ namespace :import do
     # CSV file contents as below
     # Proquest ID,Meritt Ark,UCSB Ark
     # ProQuestID:10951,ark:/13030/m30865g5,ark:/48907/f30865g5
-    Rails.logger.info 'Complete'
+    Rails.logger.info "Complete"
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'csv'
+require "csv"
 
 namespace :import do
   desc "Import merritt arks from csv for UCSB ETDs"
@@ -12,12 +12,12 @@ namespace :import do
     # ProQuestID:0035D,ark:/13030/m00999g9,ark:/48907/f30865g5
 
     puts "Beginning Import"
-    csv_text = File.read('tmp/ucsb_merritt_etds.csv')
-    csv = CSV.parse(csv_text, :headers => true)
+    csv_text = File.read("tmp/ucsb_merritt_etds.csv")
+    csv = CSV.parse(csv_text, headers: true)
     missing_etds = []
 
     csv.each do |row|
-      ucsb_ark = row[2].split('/').last
+      ucsb_ark = row[2].split("/").last
       merritt_ark = row[1]
 
       begin
@@ -30,7 +30,7 @@ namespace :import do
         missing_etds << ucsb_ark
       end
     end
-    puts "Missing ETDs: #{missing_etds.inspect}" unless missing_etds.blank?
+    puts "Missing ETDs: #{missing_etds.inspect}" if missing_etds.present?
     puts "Import Complete"
   end
 end

--- a/spec/fixtures/etds/etds-collection.xml
+++ b/spec/fixtures/etds/etds-collection.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mods:mods xsi:schemaLocation="http://www.loc.gov/mods/v3
+	http://www.loc.gov/standards/mods/v3/mods-3-4.xsd" xmlns:mods="http://www.loc.gov/mods/v3"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <mods:titleInfo usage="primary">
+    <mods:title>UCSB electronic theses and dissertations</mods:title>
+  </mods:titleInfo>
+  <mods:typeOfResource collection="yes">text</mods:typeOfResource>
+  <mods:genre authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects"
+              valueURI="http://id.loc.gov/authorities/subjects/sh85038494"
+  >Dissertations, Academic</mods:genre>
+  <mods:originInfo>
+    <mods:dateCreated>2011-</mods:dateCreated>
+    <mods:dateCreated encoding="iso8601" point="start" keyDate="yes">2011</mods:dateCreated>
+  </mods:originInfo>
+  <mods:identifier type="local">etds</mods:identifier>
+  <mods:language>
+    <mods:languageTerm authority="iso639-2b" type="code"
+                       authorityURI="http://id.loc.gov/vocabulary/iso639-2"
+                       valueURI="http://id.loc.gov/vocabulary/iso639-2/mul">mul</mods:languageTerm>
+  </mods:language>
+  <mods:abstract>In partnership with the Graduate Division, the UC Santa Barbara Library is making available
+    theses and dissertations produced by UCSB students. Currently included in ADRL are theses
+    and dissertations that were originally filed electronically, starting in 2011. In future
+    phases of ADRL, all theses and dissertations created by UCSB students may be digitized and
+    made available.</mods:abstract>
+  <mods:location>
+    <mods:physicalLocation valueURI="http://id.loc.gov/vocabulary/organizations/cusb"
+    >University of California, Santa Barbara, Main Library</mods:physicalLocation>
+  </mods:location>
+  <mods:recordInfo>
+    <mods:descriptionStandard>local</mods:descriptionStandard>
+    <mods:recordContentSource authority="marcorg"
+                              authorityURI="http://id.loc.gov/vocabulary/organizations"
+                              valueURI="http://id.loc.gov/vocabulary/organizations/cusb"
+    >CU-SB</mods:recordContentSource>
+    <mods:languageOfCataloging usage="primary">
+      <mods:languageTerm type="code" authority="iso639-2b"
+                         authorityURI="http://id.loc.gov/vocabulary/iso639-2"
+                         valueURI="http://id.loc.gov/vocabulary/iso639-2/eng">eng</mods:languageTerm>
+    </mods:languageOfCataloging>
+    <mods:recordOrigin>Human created</mods:recordOrigin>
+  </mods:recordInfo>
+</mods:mods>

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -7,6 +7,10 @@ describe ETD do
     expect(described_class.properties).to have_key "system_number"
   end
 
+  it "has merritt_id" do
+    expect(described_class.properties).to have_key "merritt_id"
+  end
+
   describe "::_to_partial_path" do
     subject { described_class._to_partial_path }
 
@@ -69,4 +73,5 @@ describe ETD do
 
     it { is_expected.to eq "catalog/document" }
   end
+
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -73,5 +73,4 @@ describe ETD do
 
     it { is_expected.to eq "catalog/document" }
   end
-
 end


### PR DESCRIPTION
**Summary**
[DIGREPO-937](https://help.library.ucsb.edu/browse/DIGREPO-937)
* Add a new metadata property `merritt_id`
* Add a rake task to process UCSB ETDs to capture Merritt arks in ADRL 

**Rake Tasks**
See `ingesting.md` to ingest ETDs 
This rake task requires the CSV attached on the DIGREPO-937 to be passed as an arg 
`bundle exec rake 'import:merritt_arks[tmp/ucsb_merritt_etds.csv]' --trace`

