### PR TITLE
Display Merritt ark on ETD view page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -721,7 +721,7 @@ GEM
       multipart-post
       oauth2
     ruby-progressbar (1.9.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.3)
     safe_yaml (1.0.4)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
@@ -915,4 +915,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -312,6 +312,9 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("identifier", :displayable),
                           label: "ARK"
 
+    config.add_show_field solr_name("merritt_id", :displayable),
+                          label: "Merritt ARK"
+
     config.add_show_field solr_name("accession_number", :symbol),
                           label: "Local Identifier"
 

--- a/app/models/concerns/metadata.rb
+++ b/app/models/concerns/metadata.rb
@@ -40,7 +40,9 @@ module Metadata
     end
 
     # For Merritt ARKs
-    property :merritt_id, predicate: RDF::Vocab::DC11.identifier
+    property :merritt_id, predicate: RDF::Vocab::DC11.identifier do |index|
+      index.as :displayable
+    end
 
     property :accession_number,
              predicate: RDF::URI(

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -53,10 +53,17 @@ describe CatalogController do
       end
 
       context "for an ETD record" do
-        let(:record) { create :public_etd, identifier: [ark] }
+        let(:merritt_id) { "ark:/13030/m00999g" }
+        let(:record) do
+          create :public_etd, identifier: [ark], merritt_id: [merritt_id]
+        end
 
         it "shows public urls (not fedora urls)" do
           expect(response.body).to include "<http://test.host/lib/#{ark}>"
+        end
+
+        it "shows merritt ark" do
+          expect(response.body).to include merritt_id
         end
       end
 


### PR DESCRIPTION
**Summary**
[DIGREPO-943](https://help.library.ucsb.edu/browse/DIGREPO-943)

* Add ETD merritt_id to solr
* Display it as Merritt ARK on ETD View

**Local ETD fixture view page**
<img width="1253" alt="ETD View Page" src="https://user-images.githubusercontent.com/45406515/62982628-9cf36980-bde1-11e9-905f-0264930aa8a0.png">
